### PR TITLE
Add shared Providers component

### DIFF
--- a/app/components/Providers.tsx
+++ b/app/components/Providers.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import React from "react";
+import AuthProvider from "../context/AuthContext";
+import { WorkspaceProvider } from "../context/WorkspaceContext";
+import { SidebarProvider } from "../context/SidebarContext";
+import { WebSocketProvider } from "../context/WebSocketContext";
+import UserSettingsProvider from "../context/UserSettingsContext";
+import { OpenAIProvider } from "../context/OpenAIContext";
+import dynamic from "next/dynamic";
+
+// Dynamically import ResponsiveLayout since it is a client side component
+const ResponsiveLayout = dynamic(() => import('./ui/ResponsiveLayout'), { ssr: false });
+
+interface ProvidersProps {
+  children: React.ReactNode;
+}
+
+export default function Providers({ children }: ProvidersProps) {
+  return (
+    <AuthProvider>
+      <OpenAIProvider>
+        <WebSocketProvider>
+          <WorkspaceProvider>
+            <SidebarProvider>
+              <UserSettingsProvider>
+                <ResponsiveLayout>{children}</ResponsiveLayout>
+              </UserSettingsProvider>
+            </SidebarProvider>
+          </WorkspaceProvider>
+        </WebSocketProvider>
+      </OpenAIProvider>
+    </AuthProvider>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,19 +2,7 @@ import './globals.css'
 import type { Metadata } from 'next'
 import { JetBrains_Mono, Crimson_Pro, Inter } from 'next/font/google'
 import React from "react";
-import dynamic from 'next/dynamic';
-import AuthProvider from './context/AuthContext';
-import { WorkspaceProvider } from './context/WorkspaceContext';
-import { SidebarProvider } from './context/SidebarContext';
-import { WebSocketProvider } from './context/WebSocketContext';
-import UserSettingsProvider from './context/UserSettingsContext';
-import { OpenAIProvider } from './context/OpenAIContext';
-
-// Import our client-side responsive layout component
-const ResponsiveLayout = dynamic(
-  () => import('./components/ui/ResponsiveLayout'),
-  { ssr: false }
-);
+import Providers from './components/Providers';
 
 // For code and main text - elegant monospace
 const jetbrainsMono = JetBrains_Mono({
@@ -51,21 +39,9 @@ export default function RootLayout({children,}: {
     // <html lang="en" className={`${jetbrainsMono.variable} ${crimsonPro.variable} bg-gray-900 text-gray-100 font-mono`}>
     <html lang="en" className={`${inter.variable} ${crimsonPro.variable} bg-gray-900 text-gray-100 font-mono`}>
       <body>
-        <AuthProvider>
-          <OpenAIProvider>
-            <WebSocketProvider>
-              <WorkspaceProvider>
-                <SidebarProvider>
-                  <UserSettingsProvider>
-                    <ResponsiveLayout>
-                      {children}
-                    </ResponsiveLayout>
-                  </UserSettingsProvider>
-                </SidebarProvider>
-              </WorkspaceProvider>
-            </WebSocketProvider>
-          </OpenAIProvider>
-        </AuthProvider>
+        <Providers>
+          {children}
+        </Providers>
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,6 @@ import ApiKeyCard from "./components/openai/ApiKeyCard";
 import { ModalControlContext } from "./context/ModalContext";
 import ContentSyncEffect from "./components/ui/ContentSyncEffect";
 import SessionDebug from "./components/auth/SessionDebug";
-import { OpenAIProvider } from "./context/OpenAIContext";
 
 export default function Home() {
   const {isAuthenticated, isLoading, token} = useAuth();
@@ -110,8 +109,7 @@ export default function Home() {
   }, [isAuthenticated, isWorkspaceSelected, token, setWorkspace]);
 
   return (
-    <OpenAIProvider>
-      <OpenAIWrapper 
+    <OpenAIWrapper
         isAuthModalOpen={isAuthModalOpen}
         isWorkspaceSelectorOpen={isWorkspaceSelectorOpen}
         isApiKeyModalOpen={isApiKeyModalOpen}
@@ -123,7 +121,6 @@ export default function Home() {
         isLoading={isLoading}
         clearWorkspace={clearWorkspace}
       />
-    </OpenAIProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- add Providers wrapper component to consolidate global providers
- simplify layout by using the Providers component
- remove redundant OpenAI provider from Home page

## Testing
- `npm run lint` *(fails: `next` not found)*